### PR TITLE
Update mactex from 20150613 to 20160603

### DIFF
--- a/Casks/mactex.rb
+++ b/Casks/mactex.rb
@@ -1,26 +1,37 @@
 cask 'mactex' do
-  version '20150613'
-  sha256 'c5f5b0fd853a17dab6e844fb5e893804af78d938fa18ee94ec3b257611a95c12'
+  version '20160603'
+  sha256 '34e5c48846a674e0025e92bf1ab7bb43a1108f729b4c26c61edcda24fa5383e3'
 
-  # ctan.org is the official download host per the vendor homepage
-  # http://mirror.ctan.org/systems/mac/mactex/mactex-#{version}.pkg
-  # cached by ie
-  url "http://www.ie.u-ryukyu.ac.jp/brew/MacTex.pkg"
+  url "http://www.ie.u-ryukyu.ac.jp/brew/mactex-#{version}.pkg"
   name 'MacTeX'
-  homepage 'http://www.tug.org/mactex/'
+  homepage 'https://www.tug.org/mactex/'
   license :oss
 
-  pkg "MacTex.pkg"
+  pkg "mactex-#{version}.pkg"
 
-  uninstall :pkgutil => [
-                         'org.tug.mactex.ghostscript9.10',
-                         'org.tug.mactex.gui2014',
-                         'org.tug.mactex.texlive2014'
-                        ],
-            :delete  => [
-                         '/Applications/TeX',
-                         '/Library/PreferencePanes/TeXDistPrefPane.prefPane',
-                         '/etc/paths.d/TeX',
-                         '/etc/manpaths.d/TeX',
-                        ]
+  uninstall pkgutil: [
+                       'org.tug.mactex.ghostscript9.19',
+                       'org.tug.mactex.gui2016',
+                       'org.tug.mactex.texlive2016',
+                     ],
+            delete:  [
+                       '/usr/local/texlive/2016',
+                       '/Applications/TeX',
+                       '/Library/PreferencePanes/TeXDistPrefPane.prefPane',
+                       '/etc/paths.d/TeX',
+                       '/etc/manpaths.d/TeX',
+                     ]
+
+  zap delete: [
+                '/usr/local/texlive/texmf-local',
+                '~/Library/texlive/2016',
+                '~/Library/Application Support/TeXShop',
+                '~/Library/Application Support/TeX Live Utility',
+                '~/Library/TeXShop',
+              ],
+      rmdir:  [
+                '/usr/local/texlive',
+                '~/Library/texlive',
+              ]
+
 end


### PR DESCRIPTION
## MacTex の Update
- 20150613 -> 20160603
- インストーラーはすでに学科サーバーに置いてもらってます
- ファイル名は `"mactex-#{version}"` のようにversion 毎に違う名前になったみたいです
